### PR TITLE
improved syntax for setting headers

### DIFF
--- a/spec/tests/core-tests.js
+++ b/spec/tests/core-tests.js
@@ -295,6 +295,15 @@ CoreTests.prototype.run = function () {
 
     module( "Remoting (xhr.js)", {
         setup:function() {
+            var srh = XMLHttpRequest.prototype.setRequestHeader;
+
+            window.headers = {};
+
+            XMLHttpRequest.prototype.setRequestHeader = function (key, val) {
+                window.headers[key] = val;
+                srh.call(this, key, val);
+            }
+
             x = x$('#xhr-test-function');
         },
         teardown:function() {
@@ -317,6 +326,17 @@ CoreTests.prototype.run = function () {
             expect(1);
             x.xhr("helpers/example.html", {async:false});
             equals(x[0].innerHTML.toLowerCase(), '<h1>this is a html partial</h1>', 'Should insert partial into element');
+        });
+
+        test( 'Setting headers', function () {
+            expect(1);
+            x.xhr("helpers/example.html", {
+                async: false,
+                headers: {
+                    'foo': 'bar',
+                }
+            });
+            equals(window.headers['foo'], 'bar', 'Should call setRequestHeader correctly');
         });
         
         

--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -100,14 +100,14 @@ xui.extend({
             method = o.method || 'get',
             async  = (typeof o.async != 'undefined'?o.async:true),           
             params = o.data || null,
-            i = 0;
+            key;
 
         req.queryString = params;
         req.open(method, url, async);
 
-        if (o.headers) {
-            for (; i<o.headers.length; i++) {
-              req.setRequestHeader(o.headers[i].name, o.headers[i].value);
+        for (key in o.headers) {
+            if (o.headers.hasOwnProperty(key)) {
+              req.setRequestHeader(key, o.headers[key]);
             }
         }
 


### PR DESCRIPTION
been doing a bunch of stuff where I need to set headers and an array of objects with name and value keys is way too verbose (pretty sure I was the moron who wrote that in the first place)
