### PR TITLE
attr() function should return array of length 0 for non-existing attributes

### DIFF
--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -116,7 +116,7 @@ xui.extend({
         }
 
         // Set "X-Request-With" header
-        req.setRequestHeader('X-Request-With','XMLHttpRequest');
+        req.setRequestHeader('X-Requested-With','XMLHttpRequest');
 
         req.handleResp = (o.callback != null) ? o.callback : function() { that.html(location, req.responseText); };
         req.handleError = (o.error && typeof o.error == 'function') ? o.error : function () {};


### PR DESCRIPTION
currently,

xui('#my-element').attr('non-existing-attribute').length == 1

It should be 0.
