### PR TITLE
attr() function should return array of length 0 for non-existing attributes

### DIFF
--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -167,8 +167,8 @@ xui.extend({
             var attrs = [];
             this.each(function(el) {
                 if (el.tagName == 'input' && attribute == 'value') attrs.push(el.value);
-                else if (el.getAttribute) {
-                    attrs.push(el.getAttribute(attribute) || '');
+                else if (el.getAttribute && el.getAttribute(attribute)) {
+                    attrs.push(el.getAttribute(attribute));
                 }
             });
             return attrs;

--- a/src/js/xhr.js
+++ b/src/js/xhr.js
@@ -116,7 +116,7 @@ xui.extend({
         }
 
         // Set "X-Request-With" header
-        req.setRequestHeader('X-Request-With','XMLHttpRequest');
+        req.setRequestHeader('X-Requested-With','XMLHttpRequest');
 
         req.handleResp = (o.callback != null) ? o.callback : function() { that.html(location, req.responseText); };
         req.handleError = (o.error && typeof o.error == 'function') ? o.error : function () {};


### PR DESCRIPTION
Currently, if you try to read an attribute of an element, and that attribute does not exist .. the attr() functions returns an array of size 1 .. which the contents of that array as an empty string.

I believe this should return an zero length / empty array.
