### PR TITLE
attr() should return zero length array for non-existing attribute

### DIFF
--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -167,8 +167,8 @@ xui.extend({
             var attrs = [];
             this.each(function(el) {
                 if (el.tagName == 'input' && attribute == 'value') attrs.push(el.value);
-                else if (el.getAttribute) {
-                    attrs.push(el.getAttribute(attribute) || '');
+                else if (el.getAttribute && el.getAttribute(attribute)) {
+                    attrs.push(el.getAttribute(attribute));
                 }
             });
             return attrs;


### PR DESCRIPTION
attr('attribute-name') function should return zero-length array if attribute does not exist. Currently, it returns an array of length 1 with an empty string value.
