### PR TITLE
xui.attr() called with non-existing attribute should return zero length array

### DIFF
--- a/spec/tests/core-tests.js
+++ b/spec/tests/core-tests.js
@@ -288,7 +288,7 @@ CoreTests.prototype.run = function () {
         });
         
         test('.attr()', function() {
-            expect(6);
+            expect(7);
             var checkbox = x$('#first-check');
             checkbox.attr('checked',true);
             equals(checkbox[0].checked, true, 'Should be able to check a checkbox-type input element');
@@ -310,6 +310,8 @@ CoreTests.prototype.run = function () {
             equals(inputValueBefore[0], "initial value", 'should existing string in input when calling attr() with one parameter.');
             textInput.attr('value','some new value');
             equals(textInput[0].value, 'some new value', 'using attr() to set value on text inputs should work.');
+            
+            equals(0, x$('#dom_tests').attr('non-existing').length);
         });
 
     // --

--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -167,8 +167,8 @@ xui.extend({
             var attrs = [];
             this.each(function(el) {
                 if (el.tagName == 'input' && attribute == 'value') attrs.push(el.value);
-                else if (el.getAttribute) {
-                    attrs.push(el.getAttribute(attribute) || '');
+                else if (el.getAttribute && el.getAttribute(attribute)) {
+                    attrs.push(el.getAttribute(attribute));
                 }
             });
             return attrs;


### PR DESCRIPTION
The xui.attr() function returns an array of length 1 with when called on a non-existing attribute. This fixes that problem and checks for the existence of the attribute before adding anything to the returned array
