### PR TITLE
Enhance xui's extend() by allowing it to copy plain javascript objects

### DIFF
--- a/spec/tests/core-tests.js
+++ b/spec/tests/core-tests.js
@@ -17,6 +17,31 @@ CoreTests.prototype.run = function () {
             x = null;
         }
     });
+        test( '.extend() called with 0 arguments should return empty object', function() {
+            expect(1);
+            deepEqual(x$.extend(), {}, 'Extended object did not match expected result.');
+        });
+        test( '.extend() called with 1 argument should extend the XUI prototype', function() {
+            expect(3);
+            var sugar = {
+                first: function() { return this[0]; },
+                last:  function() { return this[this.length - 1]; }
+            };
+
+            var returnObj = x$.extend(sugar);
+
+            ok(x$.fn.first, 'XUI prototype should be extended with the "first()" method.');
+            ok(x$.fn.last, 'XUI prototype should be extended with the "first()" method.');
+            equal(returnObj, undefined, 'extending XUI prototype, should not return anything');
+        });
+        test( '.extend() called with 2 arguments should extend the first object', function() {
+            expect(1);
+            var obj1 = { 'a':1, 'b':2, 'c':3 },
+                obj2 = { 'a':10, 'd':4};
+
+            x$.extend(obj1, obj2);
+            deepEqual(obj1, { 'a':10, 'b':2, 'c':3, 'd':4 }, 'Extended object did not match expected result.');
+        });
         test( '.find()', function(){
             expect(1);
             x = x$('#find_tests_inner').find('.foo');

--- a/src/base.js
+++ b/src/base.js
@@ -66,41 +66,81 @@ function cssstyle(name) {
 
 xui.fn = xui.prototype = {
 
-/**
-	extend
-	------
+    /**
+    	extend
+    	------
 
-	Extends XUI's prototype with the members of another object.
+		Extends and Object with properties of another Object. If only one
+		argument is given, then XUI's prototype is extended.
 
-	### syntax ###
+    	### syntax ###
 
-		xui.extend( object );
+    		xui.extend( object ); // extends XUI
+    		xui.extend( targetObject, extendingObj ); // extends targetObj
 
-	### arguments ###
+    	### arguments (variable) ###
 
-	- object `Object` contains the members that will be added to XUI's prototype.
- 
-	### example ###
+    	- object `Object` contains the members that will be added to XUI's prototype OR
+          will extend another object if arguments.length > 1
 
-	Given:
+		### returns ###
 
-		var sugar = {
-		    first: function() { return this[0]; },
-		    last:  function() { return this[this.length - 1]; }
-		}
+		- if extending XUI's prototype, then nothing is returned. If
+		  extending another object, the first object (target) is returned.
 
-	We can extend xui's prototype with members of `sugar` by using `extend`:
+    	### example ###
 
-		xui.extend(sugar);
+    	Given:
 
-	Now we can use `first` and `last` in all instances of xui:
+    		var sugar = {
+    		    first: function() { return this[0]; },
+    		    last:  function() { return this[this.length - 1]; }
+    		}
 
-		var f = x$('.button').first();
-		var l = x$('.notice').last();
-*/
-    extend: function(o) {
-        for (var i in o) {
-            xui.fn[i] = o[i];
+    	We can extend xui's prototype with members of `sugar` by using `extend`:
+
+    		xui.extend(sugar);
+
+    	Now we can use `first` and `last` in all instances of xui:
+
+    		var f = x$('.button').first();
+    		var l = x$('.notice').last();
+
+
+		Give:
+			var object1 = { a : 1, b: 2};
+			var object2 = { a : 10, c : 3 };
+
+		We can extend object1 with properties of object2:
+
+			xui.extend(object1, object2);
+
+		Now object1 will look like this:
+
+			{ a : 10, b : 2, c : 3 }
+    */
+    extend: function() {
+        var target = arguments[0] || {},
+            source = arguments[1] || {};
+
+        // if passing in only one argument, then we
+        // extend XUI's prototype
+        if (arguments.length === 1) {
+            source = target;
+            target = xui.fn;
+        }
+
+        for (var property in source) {
+            if (source[property] && source[property].constructor && source[property].constructor === Object) {
+                target[property] = target[property] || {};
+                arguments.callee(target[property], source[property]);
+            } else {
+                target[property] = source[property];
+            }
+        }
+
+        if (target !== xui.fn) {
+            return target;
         }
     },
 

--- a/src/base.js
+++ b/src/base.js
@@ -120,26 +120,28 @@ xui.fn = xui.prototype = {
 			{ a : 10, b : 2, c : 3 }
     */
     extend: function() {
-        var target = arguments[0] || {},
+        var extendingXUI = arguments.length === 1,
+            target = arguments[0] || {},
             source = arguments[1] || {};
 
-        // if passing in only one argument, then we
-        // extend XUI's prototype
-        if (arguments.length === 1) {
-            source = target;
-            target = xui.fn;
-        }
+        if (arguments.length) {
+            if (extendingXUI) {
+                source = target;
+                target = xui.fn;
+            }
 
-        for (var property in source) {
-            if (source[property] && source[property].constructor && source[property].constructor === Object) {
-                target[property] = target[property] || {};
-                arguments.callee(target[property], source[property]);
-            } else {
-                target[property] = source[property];
+            for (var property in source) {
+                // deep copy by recursion
+                if (!extendingXUI && source[property] && source[property].constructor && source[property].constructor === Object) {
+                    target[property] = target[property] || {};
+                    arguments.callee(target[property], source[property]);
+                } else {
+                    target[property] = source[property];
+                }
             }
         }
 
-        if (target !== xui.fn) {
+        if (!extendingXUI) {
             return target;
         }
     },


### PR DESCRIPTION
XUI's base extend function only extends the xui prototype. With this new functionality, if more 2 objects are passed in, then the first object is extended with the properties of the 2nd object. This also does a Deep Copy.
