### PR TITLE
Fixed a bug w the getTag() helper method

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="../packages/qunit/qunit/qunit.css" type="text/css" media="screen" title="no title" charset="utf-8">
 		<script src="../packages/qunit/qunit/qunit.js" type="text/javascript" charset="utf-8"></script>
 		<!-- make sure you include the proper build of XUI -->
-		<script src="../lib/xui-2.2.0.js" type="text/javascript" charset="utf-8"></script>
+		<script src="../lib/xui-2.2.1.js" type="text/javascript" charset="utf-8"></script>
 		<script src="tests/core-tests.js" type="text/javascript"></script>
 		<style>
 			h2#qunit-banner {

--- a/src/js/dom.js
+++ b/src/js/dom.js
@@ -180,7 +180,7 @@ xui.extend({
 });
 // private method for finding a dom element
 function getTag(el) {
-    return (el.firstChild === null) ? {'UL':'LI','DL':'DT','TR':'TD'}[el.tagName] || el.tagName : el.firstChild.tagName;
+    return (el.children[0] === undefined) ? {'UL':'LI','DL':'DT','TR':'TD'}[el.tagName] || el.tagName : el.children[0].tagName;
 }
 
 function wrapHelper(html, el) {


### PR DESCRIPTION
If the first child was a comment node, it returned a tagname of 'undefined'. 

This effect was trickling down to effect the x$().html() functionality. I was trying to add some html as a string, and it was getting wrapped in a tag w 'undefined' as the tagname.

I fixed it, built and ran the 'spec.html' file. There were 5 tests that didn't pass, but those didn't pass before I made my change (FYI -- I did put the test file / repo on my dropbox so that I could test against a true URL, not a filepath, I know that xhr doesn't like filepaths sometimes).

Thanks! I love the library!
