### PR TITLE
Fix x$(window) behaviour on Safari 5.1.

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -175,12 +175,12 @@ xui.fn = xui.prototype = {
               ele = slice(ele);
             } else if (q instanceof Array) {
                 ele = q;
-            } else if (q.toString() == '[object NodeList]' ||
-q.toString() == '[object HTMLCollection]' || typeof q.length == 'number') {
-                ele = slice(q);
             } else if (q.nodeName || q === window) { // only allows nodes in
                 // an element was passed in
                 ele = [q];
+            } else if (q.toString() == '[object NodeList]' ||
+q.toString() == '[object HTMLCollection]' || typeof q.length == 'number') {
+                ele = slice(q);
             }
         }
         // disabling the append style, could be a plugin (found in more/base):


### PR DESCRIPTION
On release 2.3.0 there is a bug caused by the fact that `window` objects in Safari define a numeric length of 0.

Because of the testing order xui calls `slice(window)`, which in turn returned an empty array and breaks the code.

This patch just inverts the testing order and everything works.
